### PR TITLE
Switch yaml to use pip

### DIFF
--- a/environments/everything.yaml
+++ b/environments/everything.yaml
@@ -1,24 +1,20 @@
 name: benchmark
-channels:
-  - pytorch
-  - nvidia
 dependencies:
   - python=3.10
   - pip
-  - pytorch
-  - torchvision
-  - torchaudio
-  - pytorch-cuda=12.4
-  - boto3
   - pip:
-      - mlflow>=1.0
+      - torch
+      - torchvision
+      - torchaudio
+      - torchtune
       - tensorflow
       - tensorboardX
-      - transformers
+      - mlflow>=1.0
+      - boto3
       - peft
+      - transformers
       - datasets
       - psutil
       - radt
       - pydantic_yaml
       - outlines
-      - torchtune


### PR DESCRIPTION
PyTorch has deprecated its conda channel, see: https://github.com/pytorch/pytorch/issues/138506 The current yaml does not support the newest versions of cuda. Packages should be installed via pip instead.
I've also moved boto3 to pip as that was the only non-pip package left.